### PR TITLE
fix tester not working on Linux

### DIFF
--- a/PhilosophersChecker.py
+++ b/PhilosophersChecker.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 import subprocess
 import fcntl


### PR DESCRIPTION
Update the hashbang to make it more portable. Previously on Ubuntu Linux on the codam computers it would output this error:
`./PhilosophersChecker.py: bad interpreter: /usr/bin/python: no such file or directory`

Thanks for making this tester btw :D